### PR TITLE
fix: restore broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,4 +343,4 @@ docker compose logs -f wechat-selkies
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=nickrunning/wechat-selkies&type=Date)](https://www.star-history.com/#nickrunning/wechat-selkies&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=nickrunning/wechat-selkies&type=Date)](https://star-history.dera.page/#nickrunning/wechat-selkies&Date)

--- a/README_en.md
+++ b/README_en.md
@@ -342,4 +342,4 @@ This project is licensed under **MIT License**. See the [LICENSE](LICENSE) file 
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=nickrunning/wechat-selkies&type=Date)](https://www.star-history.com/#nickrunning/wechat-selkies&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=nickrunning/wechat-selkies&type=Date)](https://star-history.dera.page/#nickrunning/wechat-selkies&Date)


### PR DESCRIPTION
The Star History chart in the README is currently broken because of GitHub stargazer API restrictions, leaving the section blank. This change points it at star-history.dera.page, an alternative that uses a different data source requiring no API token, so the chart renders again.